### PR TITLE
Add NativShark to courses list; fix typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -131,7 +131,7 @@ Similarly to Tobira, Minna no Nihongo is intended for intermediate-level student
 * [Hacking Kanji](https://nihongoshark.com/learn-kanji/) - Guide: 2,200 Kanji in 97 Days.
 * [Kanji Koohii](https://kanji.koohii.com/) - Help you complete the kanji learning method called Remembering the Kanji.
 * [Kanji Damage](http://www.kanjidamage.com/introduction) - A Kanji learning method.
-* [Wakikani](https://www.wanikani.com/) - Kanji learning platform.:moneybag:
+* [Wanikani](https://www.wanikani.com/) - Kanji learning platform.:moneybag:
 * Anki Deck
 	* [DJT Anki Guide](https://djtguide.neocities.org/anki.html) - A guide for downloading/customizing Anki with a link to the popular 6k/2k deck
 	* [Kodansha kanji learner's course with vocabulary](https://ankiweb.net/shared/info/779483253) - :card_index:This deck is meant to be used together with the Kodansha Kanji Learner's Course book (KLC).

--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,7 @@ Similarly to Tobira, Minna no Nihongo is intended for intermediate-level student
 * [Easy Japanese](https://www.nhk.or.jp/lesson/english/index.html) - Made by NHK in multiple languages:baby:
 * [Erin's Challenge](https://www.erin.ne.jp/en/) - Video based Japanese lessons:man:
 * [LingoDeer](https://www.lingodeer.com/) - Japanese course on a new learning app similar to Duolingo, but made with a focus on East Asian languages.:iphone:
+* [NativShark](https://nativshark.com/) - All in one Japanese learning platform, combining vocab, grammar, kanji and speaking practice.:moneybag:
 * [NHK高校講座 / NHK High School Course](https://www.nhk.or.jp/kokokoza/) - Video or audio of high school course made by NHK.Easy to study the basic glossaries of different field.:man:
 
 ## Hiragana and Katakana


### PR DESCRIPTION
This PR adds NativShark to the courses section, which is a paid all in one learning platform in English.