### PR TITLE
Add TabiTalk to Speaking and Dictionary

### DIFF
--- a/mobile.md
+++ b/mobile.md
@@ -58,11 +58,14 @@
 
 ## Speaking
 
+- [TabiTalk](https://tabitalk.com) - Mobile app that turns the phrases you translate / ask about into short real-life conversation drills.
+
 ## Dictionary
 
 - [Japanese](https://www.japaneseapp.com/) - Japanese dictionary. :apple: :robot:
 - [Akebi](https://play.google.com/store/apps/details?id=com.craxic.akebifree) - Japanese dictionary, supports exporting words to Anki. :robot:
 - [Takoboto](https://play.google.com/store/apps/details?id=jp.takoboto&hl=en_US&gl=US) - Japanese dictionary. :robot:
+- [TabiTalk](https://tabitalk.com) - Insert a sentence, and get token by token lookup. Includes translations and practice.
 
 ## Language Exchange
 

--- a/readme.md
+++ b/readme.md
@@ -223,6 +223,7 @@ Similarly to Tobira, Minna no Nihongo is intended for intermediate-level student
 ## Speaking
 
 - [Online Japanese Accent Dictionary](http://www.gavo.t.u-tokyo.ac.jp/ojad/) - Learn the correct accent to properly pronounce Japanese words. Lists of words are categorized by textbook.
+- [TabiTalk](https://tabitalk.com) - Mobile app that turns the phrases you translate / ask about into short real-life conversation drills.
 
 ## Community
 
@@ -293,6 +294,7 @@ Similarly to Tobira, Minna no Nihongo is intended for intermediate-level student
   - [Jiten](https://play.google.com/store/apps/details?id=dev.obfusk.jiten) - Android Japanese dictionary and kanji lookup app, also has web version. :robot:
   - [Japanese](https://www.japaneseapp.com/) - Dictionary, stroke order and flashcards for iOS :iphone:
   - [Midori (Japanese Dictionary)](https://apps.apple.com/it/app/midori-japanese-dictionary/id385231773) - Dictionary, stroke order and flashcards for iOS :iphone: :computer:
+  - [TabiTalk](https://tabitalk.com) - Insert a sentence, and get token by token lookup. Includes translations and practice.
 
 ## Software
 


### PR DESCRIPTION
# Awesome-Japanese Pull Request

## Description
Added TabiTalk to the Speaking and Dictionary section. It is a mobile app that turns real-life Japanese phrases you translate/ask about into short conversation drills. All Japanese phrases have a token breakdown and dictionary lookup to help learners understand each word and grammar particle.

## Type of change
<!-- Put an `x` in all the boxes that apply -->
- [x] New addition to the list
- [ ] Update to an existing item
- [ ] Removal of an item
- [ ] Documentation improvement

## Checklist
<!-- Put an `x` in all the boxes that apply -->
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [x] The item I am adding is awesome and fits the theme of this list
- [x] The link is working and points to the intended content
- [x] The description is concise and informative
- [x] I have added the item to the appropriate category
- [x] I am the owner/creator of the item

## Additional Notes
I’m the creator of TabiTalk. Added it to Speaking and Dictionary as I feel it adds the most unique value in those 2 categories.