### PR TITLE
Add After Hours podcast to Listening > Podcast section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -219,6 +219,7 @@ Similarly to Tobira, Minna no Nihongo is intended for intermediate-level student
   - [NHK News Podcast](https://www.nhk.or.jp/podcasts/) - Three podcasts available: Japanese news :older_man:, English news, and Easy Japanese.
   - [Bilingual News](http://bilingualnews.libsyn.com/) - Bilingual English and Japanese news podcast. Casual and unedited colloquial language learning experience through a weekly review of relevant news topics. :older_man:
   - [Nihongo con Teppei](https://nihongoconteppei.com/) - Japanese podcast for beginners
+  - [After Hours｜アフターアワーズ](https://open.spotify.com/show/796e85RinDEQPfm0YAwbfQ) - Two Japanese friends discuss real life topics in natural, unscripted Japanese. Great for immersion practice. :man:
 
 ## Speaking
 

--- a/readme.md
+++ b/readme.md
@@ -219,7 +219,7 @@ Similarly to Tobira, Minna no Nihongo is intended for intermediate-level student
   - [NHK News Podcast](https://www.nhk.or.jp/podcasts/) - Three podcasts available: Japanese news :older_man:, English news, and Easy Japanese.
   - [Bilingual News](http://bilingualnews.libsyn.com/) - Bilingual English and Japanese news podcast. Casual and unedited colloquial language learning experience through a weekly review of relevant news topics. :older_man:
   - [Nihongo con Teppei](https://nihongoconteppei.com/) - Japanese podcast for beginners
-  - [After Hours｜アフターアワーズ](https://afterhours-e20.pages.dev/) - Two Japanese friends discuss real life topics in natural, unscripted Japanese. Great for immersion practice. :man:
+  - [After Hours｜アフターアワーズ](https://afterhours-e20.pages.dev/) - Two Japanese friends chat about real life in natural, unscripted Japanese. Great for immersion. :man:
 
 ## Speaking
 

--- a/readme.md
+++ b/readme.md
@@ -219,7 +219,7 @@ Similarly to Tobira, Minna no Nihongo is intended for intermediate-level student
   - [NHK News Podcast](https://www.nhk.or.jp/podcasts/) - Three podcasts available: Japanese news :older_man:, English news, and Easy Japanese.
   - [Bilingual News](http://bilingualnews.libsyn.com/) - Bilingual English and Japanese news podcast. Casual and unedited colloquial language learning experience through a weekly review of relevant news topics. :older_man:
   - [Nihongo con Teppei](https://nihongoconteppei.com/) - Japanese podcast for beginners
-  - [After Hours｜アフターアワーズ](https://open.spotify.com/show/796e85RinDEQPfm0YAwbfQ) - Two Japanese friends discuss real life topics in natural, unscripted Japanese. Great for immersion practice. :man:
+  - [After Hours｜アフターアワーズ](https://afterhours-e20.pages.dev/) - Two Japanese friends discuss real life topics in natural, unscripted Japanese. Great for immersion practice. :man:
 
 ## Speaking
 


### PR DESCRIPTION
## What

Adds [After Hours｜アフターアワーズ](https://open.spotify.com/show/796e85RinDEQPfm0YAwbfQ) to the Listening > Podcast section.

Related to #92.

## Why

The current podcast list has mostly learning-focused podcasts (slow Japanese, bilingual, lesson-based). After Hours fills a gap for **intermediate-advanced learners looking for natural, unscripted conversation** — the kind of authentic content that immersion learners need.

**About the podcast:**
- Two Japanese guys in their early 20s talking about everyday topics (relationships, society, culture, comedy)
- 100% natural speech — no scripted dialogue, real casual Japanese (若者言葉)
- 60+ episodes, weekly releases
- English summaries in episode descriptions to help learners follow along
- Available on Spotify, Apple Podcasts, and via RSS
- JLPT Level: N3-N1 range

## Change

Added one line to the Podcast subsection under Listening, tagged as `:man:` (intermediate).

**Disclosure**: I am affiliated with this podcast.