### PR TITLE
Add Naruhodo to Chrome Browser Extensions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -312,6 +312,7 @@ Similarly to Tobira, Minna no Nihongo is intended for intermediate-level student
     - [rikaigu](https://chrome.google.com/webstore/detail/rikaigu/gmgccdlimakdipjjogccblkaoipdklcb) - Rikaikun enhanced. Translate Japanese by hovering over words.
     - [IPA furigana](https://chrome.google.com/webstore/detail/ipa-furigana/jnnbgnfnncobhklficfkdnclohaklifi) - Looks up the readings for kanji words and inserts them as Furigana.
     - [ReadNihon](https://chrome.google.com/webstore/detail/readnihon/gpbdeemekjaigcjldahhmckkfbkmebfd) - ReadNihon generates website Furigana by JLPT level. It also allows you to save known words that are ignored from Furigana conversion.
+    - [Naruhodo](https://chromewebstore.google.com/detail/naruhodo-—-furigana-japan/olkenlejikehefdanolhknlgfagihdkb) - Adds furigana, hover dictionary (JMdict), grammar pattern recognition, conjugation breakdown, and JLPT-adaptive reading to any Japanese webpage. Runs fully offline. :satellite:
   - Safari
     - [Safarikai](https://ashchan.github.io/safarikai/) - Rikaichan's Safari extension version.
     - [Toucan - Language Learning](https://jointoucan.com/) - When you visit a website, Toucan automatically translates certain words and phrases on the page into the language you're trying to learn. :iphone:


### PR DESCRIPTION
Adds [Naruhodo](https://chromewebstore.google.com/detail/naruhodo-—-furigana-japan/olkenlejikehefdanolhknlgfagihdkb) to the Chrome Browser Extensions section.

Naruhodo is a free Chrome extension for Japanese reading assistance. Key features:

- Furigana on any Japanese webpage
- Hover dictionary with full JMdict (215K entries)
- 694 grammar pattern labels (N5–N1)
- Conjugation chain breakdown
- JLPT-adaptive furigana (skip words you already know)
- Vocab bank with Anki export
- Runs 100% offline, no data leaves the browser

It's free with no premium tier or ads.