### PR TITLE
Add KanjiDraw to Kanji section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -158,6 +158,7 @@ Similarly to Tobira, Minna no Nihongo is intended for intermediate-level student
 - [Kakijun](https://kakijun.jp/) - Help you find the stroke order of a kanji. :jp:
 - [Kanji Explorer](https://kanjiexplorer.com) - Navigate kanji using radicals
 - [The Kanji Map](https://thekanjimap.com) - Explore kanji decomposition as an interactive graph
+- [KanjiDraw](https://kanjidraw.com) - Kanji drawing and learning practice app with stroke-order puzzles, gamified drawing phases, multilingual meanings, and a draw-to-search dictionary. :baby:
 
 ## Vocabulary
 


### PR DESCRIPTION
Hi! I'd like to add KanjiDraw to the Kanji section.

KanjiDraw is a free browser-based kanji writing practice app featuring:
- Stroke-order puzzles with guided and free drawing phases
- Gamified learning (not just flashcards)
- Multilingual meanings
- Draw-to-search kanji dictionary
- No account required

Disclosure: I'm the developer of this app.

Related to #97

# Awesome-Japanese Pull Request

## Description
<!-- Briefly describe what you are adding or changing -->

## Type of change
<!-- Put an `x` in all the boxes that apply -->
- [x] New addition to the list
- [ ] Update to an existing item
- [ ] Removal of an item
- [ ] Documentation improvement

## Checklist
<!-- Put an `x` in all the boxes that apply -->
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [x] The item I am adding is awesome and fits the theme of this list
- [x] The link is working and points to the intended content
- [x] The description is concise and informative
- [x] I have added the item to the appropriate category
- [x] I am the owner/creator of the item

## Additional Notes
<!-- Any additional information that might be helpful for reviewers -->
