### PR TITLE
Add Pokelingo to Vocabulary section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -174,6 +174,7 @@ Similarly to Tobira, Minna no Nihongo is intended for intermediate-level student
 - [SakeSaySo](https://sakesayso.com/) - A Japanese-English dictionary app featuring SRS flashcards, daily news translations for sentence-based learning, vocabulary inspection, and example sentences. Supports offline use. :iphone:
 - [Japanese Drop](https://japanesedrop.com/learn) - Free reference guides covering greetings, phrases, numbers, honorifics, particles, and more, with word breakdowns, cultural context, and audio. Also offers a free daily Japanese lesson newsletter. :baby: 
 - [hifumi](https://vitto4.github.io/hifumi/) - A flashcards companion app tailored for Minna no Nihongo Shokyū I & II textbooks ([sources](https://github.com/vitto4/hifumi)). :iphone: :computer:
+- [Pokelingo](https://pokelingo.io/en/riddle/?lang=ja) - Daily reading puzzle: read a Pokédex entry in Japanese and guess the Pokémon in five tries. All 1,025 Pokémon names with katakana practice in context. :iphone: :baby:
 
 ## Grammar
 


### PR DESCRIPTION
Hi! Adding Pokelingo to the Vocabulary section. See linked issue for context.

Related to #102

# Awesome-Japanese Pull Request

## Description
Adds Pokelingo, a daily Pokédex reading puzzle, to the Vocabulary section.

## Type of change
- [x] New addition to the list
- [ ] Update to an existing item
- [ ] Removal of an item
- [ ] Documentation improvement

## Checklist
- [x] I have read the contribution guidelines
- [x] The item I am adding is awesome and fits the theme of this list
- [x] The link is working and points to the intended content
- [x] The description is concise and informative
- [x] I have added the item to the appropriate category
- [x] I am the owner/creator of the item

## Additional Notes
Pokelingo is a daily Pokémon reading puzzle. You read a real in-game Pokédex entry in Japanese and guess which of the 1,025 Pokémon it describes within five tries. The dex entries use natural N4-N5 grammar, so it works as low-friction reading practice on top of vocabulary acquisition for Pokémon names. Free, no signup, no ads, browser-based.

Disclosure: I'm the creator.