### PR TITLE
Add KaChiKa JA to Vocabulary section

### DIFF
--- a/mobile.md
+++ b/mobile.md
@@ -46,6 +46,7 @@
 
 - [Anki](https://apps.ankiweb.net/) - Japanese vocabulary learning app. :apple: :robot:
 - [Memrise](https://www.memrise.com/) - Community driven Japanese vocabulary learning app. :apple: :robot:
+- [KaChiKa JA](https://kachika.app/) - AI photo-to-vocabulary app: snap a photo to extract Japanese words with example sentences, FSRS-scheduled reviews. :apple: :robot: :moneybag:
 
 ## Grammar
 

--- a/readme.md
+++ b/readme.md
@@ -176,6 +176,7 @@ Similarly to Tobira, Minna no Nihongo is intended for intermediate-level student
 - [Japanese Drop](https://japanesedrop.com/learn) - Free reference guides covering greetings, phrases, numbers, honorifics, particles, and more, with word breakdowns, cultural context, and audio. Also offers a free daily Japanese lesson newsletter. :baby:
 - [hifumi](https://vitto4.github.io/hifumi/) - A flashcards companion app tailored for Minna no Nihongo Shokyū I & II textbooks ([sources](https://github.com/vitto4/hifumi)). :iphone: :computer:
 - [Pokelingo](https://pokelingo.io/en/riddle/?lang=ja) - Daily reading puzzle: read a Pokédex entry in Japanese and guess the Pokémon in five tries. All 1,025 Pokémon names with katakana practice in context. :iphone: :baby:
+- [KaChiKa JA](https://kachika.app/) - AI photo-to-vocabulary app for Japanese learners. Snap a photo of anything around you to extract Japanese words with example sentences, scheduled for review with FSRS. All images stored locally. :iphone: :moneybag:
 
 ## Grammar
 


### PR DESCRIPTION
## Description

Adds **KaChiKa JA** to the **Vocabulary** section of both `readme.md` and `mobile.md`. KaChiKa JA is an AI photo-to-vocabulary app dedicated to Japanese learners: snap a photo of anything around you (a 弁当, a 駅 sign, a 自動販売機) and it extracts the Japanese words, generates real example sentences, and schedules reviews with FSRS (Free Spaced Repetition Scheduler). Images are processed and stored on-device.

> **Disclaimer:** I'm the creator of KaChiKa JA. Adding this per the contribution guidelines' owner-transparency rule.

## Type of change

- [x] New addition to the list
- [ ] Update to an existing item
- [ ] Removal of an item
- [ ] Documentation improvement

## Checklist

- [x] I have read the contribution guidelines
- [x] The item I am adding is awesome and fits the theme of this list
- [x] The link is working and points to the intended content
- [x] The description is concise and informative
- [x] I have added the item to the appropriate category
- [x] I am the owner/creator of the item (disclaimer added above for transparency)

## Additional Notes

- Added to **Vocabulary** in both files; `mobile.md` stays within its 5-entry limit (3 entries after this PR).
- Indicators: `readme.md` `:iphone: :moneybag:` (mobile app with in-app purchases); `mobile.md` `:apple: :robot: :moneybag:` (iOS + Android + IAP).
- Rebased onto the latest `master` to resolve the merge conflict (upstream added Pokelingo at the same spot); KaChiKa JA now sits at the end of the Vocabulary list.
