### PR TITLE
Add Japanese Daily News podcast (podcast.jpnotes.dev)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -226,6 +226,7 @@ Similarly to Tobira, Minna no Nihongo is intended for intermediate-level student
   - [Learn Japanese Pod](https://learnjapanesepod.com/) - Japanese language learning podcast.
   - [JapanesePod101](https://www.japanesepod101.com/) - Japanese language learning podcast with multiple levels and web platform.
   - [News in Slow Japanese](http://newsinslowjapanese.com/) - Listen to Japanese News in slow speed. :moneybag:
+  - [Japanese Daily News](https://podcast.jpnotes.dev/) - Daily news podcast for learners, slow audio with vocab and grammar. :baby:
   - [NHK News Podcast](https://www.nhk.or.jp/podcasts/) - Three podcasts available: Japanese news :older_man:, English news, and Easy Japanese.
   - [Bilingual News](http://bilingualnews.libsyn.com/) - Weekly bilingual English/Japanese news podcast with casual, unedited colloquial conversation. :older_man:
   - [Nihongo con Teppei](https://nihongoconteppei.com/) - Japanese podcast for beginners


### PR DESCRIPTION
# Awesome-Japanese Pull Request

## Description
Adds **[Japanese Daily News](https://podcast.jpnotes.dev/)** to **Listening › Podcast**. A free daily podcast that retells real Japanese news at a slow, learner-friendly pace, with vocabulary and grammar support and native-style audio. Also on Apple Podcasts and Spotify. Complements the existing News in Slow Japanese / NHK News entries (this one is free).

## Type of change
- [x] New addition to the list
- [ ] Update to an existing item
- [ ] Removal of an item
- [ ] Documentation improvement

## Checklist
- [x] I have read the [contribution guidelines](contributing.md)
- [x] The item I am adding is awesome and fits the theme of this list
- [x] The link is working and points to the intended content
- [x] The description is concise and informative
- [x] Item description is under 100 characters (excluding emoji)
- [x] I have added the item to the appropriate category
- [x] I understand this PR may be automatically closed after 90 days if there is no follow-up after a requested change

## Your Role
- [x] I'm affiliated with this item
- [ ] I'm nominating this item

## Additional Notes
I produce and maintain this podcast — disclosing affiliation per the guidelines.