### PR TITLE
Add Picute Subtitle Encoding Fixer under Video > Subtitles

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -285,6 +285,7 @@ Similarly to Tobira, Minna no Nihongo is intended for intermediate-level student
   - [mirumoji](https://github.com/svdC1/mirumoji) - Self-hosted, open-source video player with Japanese subtitle tokenization, JMDict, and Anki export. 👴
 - Subtitles
   - [kitsunekko](https://kitsunekko.net/dirlist.php?dir=subtitles%2Fjapanese%2F) - Repository of Japanese subtitles for many series
+  - [Picute Subtitle Encoding Fixer](https://picute.net/en/tools/subtitle-encoding-converter) - Free in-browser repair of garbled (mojibake) Japanese subtitles: re-decodes Shift-JIS to UTF-8.
 - See also: [**Japanese TV Channels**](https://japantv.app) - browse Japanese TV networks on YouTube (live & latest) with an interactive player.
 
 ## Dictionary


### PR DESCRIPTION
# Awesome-Japanese Pull Request

## Description
Adds **Picute Subtitle Encoding Fixer** under **Video → Subtitles** (next to kitsunekko). It is a free, in-browser tool that repairs garbled (mojibake) Japanese subtitle files by re-decoding legacy **Shift-JIS → UTF-8** — a common problem when opening older `.srt` files for Japanese media. Nothing is uploaded; everything runs locally in the browser.

## Type of change
- [x] New addition to the list
- [ ] Update to an existing item
- [ ] Removal of an item
- [ ] Documentation improvement

## Checklist
- [x] I have read the [contribution guidelines](contributing.md)
- [x] The item I am adding is awesome and fits the theme of this list
- [x] The link is working and points to the intended content
- [x] The description is concise and informative
- [x] Item description is under 100 characters (excluding emoji)
- [x] I have added the item to the appropriate category
- [x] I understand this PR may be automatically closed after 90 days if there is no follow-up after a requested change

## Your Role
- [x] I'm affiliated with this item
- [ ] I'm nominating this item

## Additional Notes
Description is 95 visible characters (within the 100-char custom limit); 2-space indent under the Subtitles list (MD007); `markdownlint-cli2 readme.md` → 0 errors locally.
