### PR TITLE
Add ListenRadio (リスラジ) to Listening

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -224,6 +224,7 @@ Similarly to Tobira, Minna no Nihongo is intended for intermediate-level student
 - [Delvin](https://delvinlanguage.com) - Practice Japanese listening and reading with authentic Japanese video.
 - [mykikitori](https://www.mykikitori.com/) - Practice your Japanese listening skills.
 - [Tsunahiro](https://tsunagarujp.bunka.go.jp) - Website for Foreign Nationals as Residents to Learn Japanese Language
+- [ListenRadio (リスラジ)](https://listenradio.jp/) - Live streams from community FM stations across Japan. :jp: :japan: :iphone:
 - Podcast
   - [Podcast Ranking](https://podcastranking.jp/) - Japanese Podcast ranking website, discover Japanese language podcasts.
   - [Learn Japanese Pod](https://learnjapanesepod.com/) - Japanese language learning podcast.


### PR DESCRIPTION
# Awesome-Japanese Pull Request

## Description
Adds **ListenRadio (リスラジ)** to the **Listening** section — a service that aggregates live streams from community FM (コミュニティFM) stations across Japan.

Note on access: the site has a full web player (HLS.js), but the audio stream is geo-restricted to Japanese IPs — outside Japan it silently fails to start. A native iOS/Android app is also offered. Flagged accordingly with `:japan:` (Japan IP restricted), `:jp:` (Japanese UI only), and `:iphone:` (mobile app). No `:moneybag:` — the service carries no paid tier.

## Type of change
- [x] New addition to the list
- [ ] Update to an existing item
- [ ] Removal of an item
- [ ] Documentation improvement

## Checklist
- [x] I have read the [contribution guidelines](contributing.md)
- [x] The item I am adding is awesome and fits the theme of this list
- [x] The link is working and points to the intended content
- [x] The description is concise and informative, and does not use the word "free" (items without `:moneybag:` are already considered free)
- [x] Pricing is marked correctly: I added the `:moneybag:` emoji if the item has freemium tiers, in-app purchases, or paid plans
- [x] If the item starts charging money after this PR is merged (paid plans, in-app purchases, or freemium tiers), I will revise its description here to add the `:moneybag:` emoji — otherwise the entry may be removed without warning
- [x] Item description is under 100 characters (excluding emoji)
- [x] I have added the item to the appropriate category
- [x] I understand this PR may be automatically closed after 90 days if there is no follow-up after a requested change

## Your Role
- [ ] I'm affiliated with this item
- [x] I'm nominating this item

## Survey: AI Assistance (Optional)
<!-- Only asked if affiliated; not applicable here. -->
- [ ] Little to none (<10%) — I wrote it myself
- [ ] Side by side (~10–50%) — AI assisted, I directed
- [ ] Mostly AI (>50%) — AI did most of the work

## Additional Notes
Web playback was verified in-browser: the player loads `hls.min.js` plus a provider-hosted `globalIpcheck.js` geo-gate, and the stream never starts from a non-Japanese IP (media element stays `readyState: 0`, play button never toggles to pause). Hence the `:japan:` flag rather than a `:warning:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
