### PR TITLE
Add Dekitaidan Telegram community to Community (#78)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -248,6 +248,8 @@ Similarly to Tobira, Minna no Nihongo is intended for intermediate-level student
   - [日本語と英語](https://discord.com/invite/ri-ben-yu-toying-yu-jp-en-116379774825267202) - Another popular English/Japanese discord chat server.
   - [Reddit Masterlist](https://www.reddit.com/r/languagelearning/comments/5m5426/discord_language_learning_servers_masterlist/) - Reddit masterlist of language-learning Discord servers; see the East Asian Languages section.
   - [TheMoeWay](https://discord.gg/nhqjydaR8j) - Highly active discord chat server for an immersion Japanese learner with immersion logs
+- [Telegram](https://telegram.org/) - Popular messenger app. :iphone: :computer:
+  - [Dekitaidan](https://t.me/dekitaidan) - Russian-speaking Telegram community for Japanese learners and resources.
 - [HelloTalk](https://www.hellotalk.com/) - Popular language exchange app. :iphone:
 
 ## Video


### PR DESCRIPTION
# Awesome-Japanese Pull Request

Resolves #78.

## Description
Adds **Dekitaidan**, a Russian-speaking Telegram community for Japanese learners, to the **Community** section — as requested in #78. A **Telegram** platform entry is added alongside the existing Discord entry, with Dekitaidan nested under it (mirroring the Discord sub-list structure).

Per the maintainer's feedback on the issue, the wording avoids "biggest" and uses the suggested descriptive text instead. No `:moneybag:` — the community carries no paid tier.

## Type of change
- [x] New addition to the list
- [ ] Update to an existing item
- [ ] Removal of an item
- [ ] Documentation improvement

## Checklist
- [x] I have read the [contribution guidelines](contributing.md)
- [x] The item I am adding is awesome and fits the theme of this list
- [x] The link is working and points to the intended content
- [x] The description is concise and informative, and does not use the word "free" (items without `:moneybag:` are already considered free)
- [x] Pricing is marked correctly: I added the `:moneybag:` emoji if the item has freemium tiers, in-app purchases, or paid plans
- [x] If the item starts charging money after this PR is merged (paid plans, in-app purchases, or freemium tiers), I will revise its description here to add the `:moneybag:` emoji — otherwise the entry may be removed without warning
- [x] Item description is under 100 characters (excluding emoji)
- [x] I have added the item to the appropriate category
- [x] I understand this PR may be automatically closed after 90 days if there is no follow-up after a requested change

## Your Role
- [ ] I'm affiliated with this item
- [x] I'm nominating this item

## Survey: AI Assistance (Optional)
<!-- Only asked if affiliated; not applicable here. -->
- [ ] Little to none (<10%) — I wrote it myself
- [ ] Side by side (~10–50%) — AI assisted, I directed
- [ ] Mostly AI (>50%) — AI did most of the work

## Additional Notes
Originally proposed by @SharapaGorg in #78. Wording adjusted to the maintainer's suggestion in that thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
