### PR TITLE
Flag Online Japanese Accent Dictionary as Japan IP restricted

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -236,7 +236,7 @@ Similarly to Tobira, Minna no Nihongo is intended for intermediate-level student
 
 ## Speaking
 
-- [Online Japanese Accent Dictionary](http://www.gavo.t.u-tokyo.ac.jp/ojad/) - Learn correct pitch accent to pronounce Japanese words; word lists organized by textbook.
+- [Online Japanese Accent Dictionary](http://www.gavo.t.u-tokyo.ac.jp/ojad/) - Learn correct pitch accent to pronounce Japanese words; word lists organized by textbook. :japan:
 
 ## Community
 


### PR DESCRIPTION
# Awesome-Japanese Pull Request

## Description
Adds the `:japan:` badge to the **Online Japanese Accent Dictionary** (OJAD) entry under **Speaking**. OJAD (http://www.gavo.t.u-tokyo.ac.jp/ojad/) now requires a Japanese IP address to access, and the repo already defines `:japan:` = "Japan IP restricted" in the legend, so this flags the entry for users outside Japan.

## Type of change
- [x] Update to an existing item

## Checklist
- [x] I have read the [contribution guidelines](contributing.md)
- [x] The item I am adding is awesome and fits the theme of this list
- [x] The link is working and points to the intended content
- [x] The description is concise and informative, and does not use the word "free" (items without `:moneybag:` are already considered free)
- [x] Pricing is marked correctly: I added the `:moneybag:` emoji if the item has freemium tiers, in-app purchases, or paid plans
- [x] If the item starts charging money after this PR is merged (paid plans, in-app purchases, or freemium tiers), I will revise its description here to add the `:moneybag:` emoji — otherwise the entry may be removed without warning
- [x] Item description is under 100 characters (excluding emoji)
- [x] I have added the item to the appropriate category
- [x] I understand this PR may be automatically closed after 90 days if there is no follow-up after a requested change

## Your Role
- [x] I'm nominating this item

## Additional Notes
No pricing change; this is a metadata-only update to flag regional access restriction using the existing legend convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)