### PR TITLE
Remove unavailable Genki 1 & 2 Anki deck

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,8 +84,6 @@ Everyone's favorite Japanese textbook. Recommended for beginners.
   - [Genki 1 Textbook](https://www.amazon.com/dp/4789014401) | [Genki 1 Workbook](https://www.amazon.com/dp/478901441X)
   - [Genki 2 Textbook](https://www.amazon.com/dp/4789014436) | [Genki 2 Workbook](https://www.amazon.com/dp/4789014444)
   - [Genki Answer Key](https://www.amazon.com/dp/4789014479)
-- Anki Deck :card_index:
-  - [Genki 1 & 2](https://ankiweb.net/shared/info/1132238466) - All the vocab from Genki 1 & 2 and more. :warning: Still updating.
 - [Unofficial](https://sethclydesdale.github.io/genki-study-resources/) - Study tool.
 
 ### Tobira :older_man:


### PR DESCRIPTION
# Awesome-Japanese Pull Request

## Description

Removes the Genki 1 & 2 Anki deck ([AnkiWeb 1132238466](https://ankiweb.net/shared/info/1132238466)) — the linked deck is no longer available. It was the only entry under the Genki "Anki Deck" heading, so the now-empty heading is removed too.

## Type of change
- [ ] New addition to the list
- [ ] Update to an existing item
- [x] Removal of an item
- [ ] Documentation improvement

## Checklist
- [x] I have read the [contribution guidelines](contributing.md)
- [x] The item I am adding is awesome and fits the theme of this list
- [x] The link is working and points to the intended content
- [x] The description is concise and informative, and does not use the word "free" (items without `:moneybag:` are already considered free)
- [x] Pricing is marked correctly: I added the `:moneybag:` emoji if the item has freemium tiers, in-app purchases, or paid plans
- [x] If the item starts charging money after this PR is merged (paid plans, in-app purchases, or freemium tiers), I will revise its description here to add the `:moneybag:` emoji — otherwise the entry may be removed without warning
- [x] Item description is under 100 characters (excluding emoji)
- [x] I have added the item to the appropriate category
- [x] I understand this PR may be automatically closed after 90 days if there is no follow-up after a requested change

## Your Role
- [ ] I'm affiliated with this item
- [x] I'm nominating this item

## Survey: AI Assistance (Optional)
- [ ] Little to none (<10%) — I wrote it myself
- [ ] Side by side (~10–50%) — AI assisted, I directed
- [ ] Mostly AI (>50%) — AI did most of the work

## Additional Notes

Removal only — the item-specific checklist affirmations about adding an item are satisfied vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)