### PR TITLE
Remove Drops from Course list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,6 @@ Similarly to Tobira, Minna no Nihongo is intended for intermediate-level student
 - [LingoDeer](https://www.lingodeer.com/) - Duolingo-style app whose courses focus on East Asian languages. :iphone:
 - [NativShark](https://nativshark.com/) - All in one Japanese learning platform, combining vocab, grammar, kanji and speaking practice. :moneybag:
 - [NHK 高校講座 / NHK High School Course](https://www.nhk.or.jp/kokokoza/) - NHK high-school video/audio lessons; good for basic vocabulary across many fields. :man: :japan:
-- [Drops: Language learning app](https://languagedrops.com/) - Duolingo-like app which offers 5 minutes/day free flashcards-based app separated by categories. :iphone:
 
 ## Hiragana and Katakana
 


### PR DESCRIPTION
## Description
Removes **Drops (languagedrops.com)** from the Course list. Drops is a general multi-language vocabulary app rather than a Japanese-focused resource, and other entries in the list serve Japanese learners better.

## Type of change
- [ ] New addition to the list
- [ ] Update to an existing item
- [x] Removal of an item
- [ ] Documentation improvement

## Checklist
- [x] I have read the [contribution guidelines](contributing.md)
- [x] The item I am adding is awesome and fits the theme of this list
- [x] The link is working and points to the intended content
- [x] The description is concise and informative, and does not use the word "free" (items without `:moneybag:` are already considered free)
- [x] Pricing is marked correctly: I added the `:moneybag:` emoji if the item has freemium tiers, in-app purchases, or paid plans
- [x] If the item starts charging money after this PR is merged (paid plans, in-app purchases, or freemium tiers), I will revise its description here to add the `:moneybag:` emoji — otherwise the entry may be removed without warning
- [x] Item description is under 100 characters (excluding emoji)
- [x] I have added the item to the appropriate category
- [x] I understand this PR may be automatically closed after 90 days if there is no follow-up after a requested change

## Your Role
- [ ] I'm affiliated with this item
- [x] I'm nominating this item

## Additional Notes
Removal only — no other entries changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)