### PR TITLE
Render :robot: emoji on homepage; warn on unmapped shortcodes

### DIFF
--- a/site/build.mjs
+++ b/site/build.mjs
@@ -18,6 +18,7 @@ const EMOJI = {
   satellite: "📡", jp: "🇯🇵", japan: "🗾", moneybag: "💰", warning: "⚠️",
   book: "📖", card_index: "🗂️", tv: "📺", headphones: "🎧", mag: "🔍",
   scroll: "📜", pencil: "✏️", bulb: "💡", star: "⭐", fire: "🔥",
+  robot: "🤖",
 };
 
 const slug = (s) =>
@@ -30,8 +31,23 @@ function buildContent(md) {
   const idx = md.indexOf(startMarker);
   let body = idx >= 0 ? md.slice(idx) : md;
 
-  // Convert :shortcode: emoji.
-  body = body.replace(/:([a-z0-9_+-]+):/g, (m, name) => EMOJI[name] ?? m);
+  // Convert :shortcode: emoji. Warn on any shortcode we don't map, so a new
+  // legend entry can't silently ship as literal ":name:" text on the page.
+  const unmapped = new Set();
+  body = body.replace(/:([a-z0-9_+-]+):/g, (m, name) => {
+    if (!(name in EMOJI)) {
+      unmapped.add(name);
+      return m;
+    }
+    return EMOJI[name];
+  });
+  if (unmapped.size) {
+    console.warn(
+      `⚠️  Unmapped emoji shortcode(s) left as literal text: ${[...unmapped]
+        .map((n) => `:${n}:`)
+        .join(", ")}. Add them to EMOJI in site/build.mjs.`
+    );
+  }
 
   let html = marked.parse(body, { gfm: true });
 


### PR DESCRIPTION
## Problem

`:robot:` (the new generative-AI indicator) renders fine on GitHub's README but shows as **literal `:robot:` text on the homepage**. Root cause: `site/build.mjs` converts shortcodes via a **hardcoded `EMOJI` map**, and `robot` wasn't in it — the `?? m` fallback leaves unknown shortcodes as raw text. GitHub's native shortcode rendering masked the gap.

It's a homepage-build bug, not a readme problem. `robot` was the *only* shortcode used in the readme that was missing from the map.

## Fix

- Add `robot: "🤖"` to the `EMOJI` map.
- **Warn during the build** on any shortcode not in the map, so a future legend addition can't silently ship as literal text again (the exact failure mode here).

## Verification

Ran `node site/build.mjs` against the readme (with the pending `:robot:` tags): `index.html` renders **3× 🤖** (legend + KaChiKa JA + JIVX), **zero** literal `:robot:`, no warning (all shortcodes mapped).

## Rollout

The site rebuilds on push to `master` or manual dispatch (`build-site.yml`). Once this is merged to `homepage`, the next master push — e.g. merging the content PR #147 — will render `:robot:` as 🤖 live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)