### PR TITLE
Add JFF+ (Japan Foundation) to Watch section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -285,6 +285,7 @@ The natural successor to beginner textbooks like Genki, Quartet develops all fou
   - [Abema TV](https://abema.tv/) - Live Japanese TV stream :iphone: :japan:.
   - [NicoNico](https://www.nicovideo.jp/) - Japanese streamer platform :iphone:.
   - [DaiWEEB](https://www.daiweeb.org/) - Japanese anime with both Japanese and English subtitles.
+  - [JFF+ (Japan Foundation)](https://en.jff.jpf.go.jp/) - Japan Foundation streaming of Japanese films and shorts; some titles are region-restricted :warning:.
 - Players
   - [Memento](https://github.com/ripose-jp/Memento) - An mpv-based video player for studying Japanese.
   - [animebook](https://github.com/animebook/animebook.github.io) - In-browser video player for learning Japanese with subtitles.


### PR DESCRIPTION
# Awesome-Japanese Pull Request

## Description
Adds **JFF+ (Japan Foundation)** to the Watch section under **Video → Stream** — the Japan Foundation's official streaming platform for Japanese films and shorts. Availability is region-dependent, and unlike `:japan:` (Japan IP restricted) some titles are geo-locked *out* of Japan, so the entry carries `:warning:` with the caveat in its description.

Entry:
> - [JFF+ (Japan Foundation)](https://en.jff.jpf.go.jp/) - Japan Foundation streaming of Japanese films and shorts; some titles are region-restricted :warning:.

## Type of change
- [x] New addition to the list
- [ ] Update to an existing item
- [ ] Removal of an item
- [ ] Documentation improvement

## Checklist
- [x] I have read the [contribution guidelines](contributing.md)
- [x] The item I am adding is awesome and fits the theme of this list
- [x] The link is working and points to the intended content
- [x] The description is concise and informative, and does not use the word "free" (items without `:moneybag:` are already considered free)
- [x] Pricing is marked correctly: I added the `:moneybag:` emoji if the item has freemium tiers, in-app purchases, or paid plans
- [x] Generative AI is marked correctly: I added the `:robot:` emoji if the item uses generative AI in the product, or if generative AI did most (>50%) of building it
- [x] If the item starts charging money after this PR is merged (paid plans, in-app purchases, or freemium tiers), I will revise its description here to add the `:moneybag:` emoji — otherwise the entry may be removed without warning
- [x] Item description is under 100 characters (excluding emoji)
- [x] I have added the item to the appropriate category
- [x] I understand this PR may be automatically closed after 90 days if there is no follow-up after a requested change

## Your Role
- [ ] I'm affiliated with this item
- [x] I'm nominating this item

## Additional Notes
JFF+ is free to watch (no `:moneybag:`) and does not use generative AI (no `:robot:`). It is a viewing platform, so it belongs under Video → Stream alongside Abema/NicoNico. `awesome-lint` passes; description is 90 characters excluding the emoji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- template re-validated -->
