### PR TITLE
Remove Google Drive textbook links over copyright concern

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,6 @@
   - [Tobira](#tobira)
   - [Minna no Nihongo](#minna-no-nihongo)
   - [Quartet](#quartet)
-  - [Other textbooks](#other-textbooks)
 - [Course](#course)
 - [Hiragana and Katakana](#hiragana-and-katakana)
 - [Kanji](#kanji)
@@ -113,10 +112,6 @@ The natural successor to beginner textbooks like Genki, Quartet develops all fou
   - [Quartet 2 Textbook](https://www.amazon.com/dp/4789017451)
   - [Quartet 2 Workbook](https://www.amazon.com/dp/478901746X)
 - [Quartet Vocab & Kanji app](https://play.google.com/store/apps/details?id=jp.quartet) - Flashcards, kanji stroke-order, and timed quizzes for the series' vocab :iphone: :moneybag:.
-
-### Other textbooks
-
-[Google Drive A](https://drive.google.com/drive/folders/0B7RbJJM_m3GDWTBVRk5mcm9YMEU?resourcekey=0-QdQYKB8lfciygD4mZNdnxw&usp=sharing) | [B](https://drive.google.com/drive/folders/0B7RbJJM_m3GDUGw3VFlVWkd0bjA?resourcekey=0-J1qnxyNU3Pa1m-LqhXkSwA) - contains links to many textbooks such as Japanese for Busy People, Japanese - The Manga Way, and An Integrated Approach to Intermediate Japanese. Additionally, it also includes some reading resources such as Yotsubato, and some listening material.
 
 ## Course
 


### PR DESCRIPTION
# Awesome-Japanese Pull Request

## Description
Remove the Google Drive textbook folder links (Other textbooks section) over copyright concerns.

## Type of change
<!-- Put an `x` in all the boxes that apply -->
- [ ] New addition to the list
- [ ] Update to an existing item
- [x] Removal of an item
- [ ] Documentation improvement

## Checklist
<!-- Put an `x` in all the boxes that apply -->
- [x] I have read the [contribution guidelines](contributing.md)
- [x] The item I am adding is awesome and fits the theme of this list
- [x] The link is working and points to the intended content
- [x] The description is concise and informative, and does not use the word "free" (items without `:moneybag:` are already considered free)
- [x] Pricing is marked correctly: I added the `:moneybag:` emoji if the item has freemium tiers, in-app purchases, or paid plans
- [x] Generative AI is marked correctly: I added the `:robot:` emoji if the item uses generative AI in the product, or if generative AI did most (>50%) of building it
- [x] If the item starts charging money after this PR is merged (paid plans, in-app purchases, or freemium tiers), I will revise its description here to add the `:moneybag:` emoji — otherwise the entry may be removed without warning
- [x] Item description is under 100 characters (excluding emoji)
- [x] I have added the item to the appropriate category
- [x] I understand this PR may be automatically closed after 90 days if there is no follow-up after a requested change

## Your Role
<!-- Please choose one option that applies to you -->
- [ ] I'm affiliated with this item
- [x] I'm nominating this item

## Survey: AI Assistance (Optional)
- [ ] Little to none (<10%) — I wrote it myself
- [ ] Side by side (~10–50%) — AI assisted, I directed
- [ ] Mostly AI (>50%) — AI did most of the work

## Additional Notes
The "Other textbooks" section linked Google Drive folders redistributing copyrighted textbooks (e.g. Japanese for Busy People). Removed the links, the now-empty section header, and its table-of-contents entry.
