### PR TITLE
Add tanku Anime to Video > Players

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -290,6 +290,7 @@ The natural successor to beginner textbooks like Genki, Quartet develops all fou
   - [mLearn](https://mlearn.kikan.net) - Language immersion app with interactive subtitles, OCR, sentence mining, and SRS :computer: :robot:.
   - [miteiru](https://github.com/hockyy/miteiru) - Open-source Electron video player to learn Japanese and other languages :older_man:.
   - [mirumoji](https://github.com/svdC1/mirumoji) - Self-hosted, open-source video player with Japanese subtitle tokenization, JMDict, and Anki export :older_man:.
+  - [tanku Anime](https://github.com/DanielDcool/tankuanime) - Self-hosted player that hides subtitles until you pause; JMdict lookup, AI breakdown, Anki export :computer: :jp: :robot:.
 - Subtitles
   - [kitsunekko](https://kitsunekko.net/dirlist.php?dir=subtitles%2Fjapanese%2F) - Repository of Japanese subtitles for many series.
 - [Japanese TV Channels](https://japantv.app) - Browse Japanese TV networks on YouTube (live and latest) with an interactive player.


### PR DESCRIPTION
# Awesome-Japanese Pull Request

## Description

Adds tanku Anime under Video > Players. Closes #162

A self-hosted player for studying Japanese with anime and drama files you already have. Subtitles stay hidden until you pause, which is the part that makes it different from the other players in that section.

## Type of change

- [x] New addition to the list
- [ ] Update to an existing item
- [ ] Removal of an item
- [ ] Documentation improvement

## Checklist

- [x] I have read the [contribution guidelines](contributing.md)
- [x] The item I am adding is awesome and fits the theme of this list
- [x] The link is working and points to the intended content
- [x] The description is concise and informative, and does not use the word "free" (items without `:moneybag:` are already considered free)
- [x] Pricing is marked correctly: I added the `:moneybag:` emoji if the item has freemium tiers, in-app purchases, or paid plans
- [x] Generative AI is marked correctly: I added the `:robot:` emoji if the item uses generative AI in the product, or if generative AI did most (>50%) of building it
- [x] If the item starts charging money after this PR is merged (paid plans, in-app purchases, or freemium tiers), I will revise its description here to add the `:moneybag:` emoji — otherwise the entry may be removed without warning
- [x] Item description is under 100 characters (excluding emoji)
- [x] I have added the item to the appropriate category
- [x] If this PR resolves an issue, I linked it with `Closes #<number>` in the description above
- [x] I understand this PR may be automatically closed after 90 days if there is no follow-up after a requested change, and that closing it will also close any issue it is linked to

## Your Role

- [x] I'm affiliated with this item
- [ ] I'm nominating this item

## Survey: AI Assistance (Optional)

- [ ] Little to none (<10%) — I wrote it myself
- [ ] Side by side (~10–50%) — AI assisted, I directed
- [x] Mostly AI (>50%) — AI did most of the work

## Additional Notes

No paid tier, so no `:moneybag:`. Tagged `:robot:` on both counts: the sentence breakdown calls an AI provider you supply a key for, and AI wrote most of the code. `:jp:` because the UI is Japanese only. Description is 99 characters by the repo's own counting rule, and `markdownlint-cli2` passes locally.
