### PR TITLE
Add Onomanabi and WaseiGo (Japanese vocabulary apps)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -180,6 +180,8 @@ The natural successor to beginner textbooks like Genki, Quartet develops all fou
 - [Pokelingo](https://pokelingo.io/en/riddle/?lang=ja) - Daily puzzle: read a Pokédex entry in Japanese and guess the Pokémon; all 1,025 names in katakana :iphone: :baby:.
 - [KaChiKa JA](https://kachika.app/) - AI photo-to-vocabulary app with example sentences and FSRS review; images stored on-device :iphone: :moneybag: :robot:.
 - [WordMeadow](https://wordmeadow.app/learn/japanese/from/english/themes) - Visual Japanese vocabulary theme cards grouped by everyday topics :computer: :baby:.
+- [Onomanabi](https://onomanabi.take-lab.com/) - Onomatopoeia trainer with an animation for every word, native notes, and similar-word maps :iphone: :computer: :moneybag: :robot:.
+- [WaseiGo](https://waseigo.take-lab.com/) - 1,000+ wasei-eigo words that look like English but mean something else, with illustrated dialogues :iphone: :moneybag: :robot:.
 
 ## Grammar
 

--- a/readme.md
+++ b/readme.md
@@ -181,7 +181,7 @@ The natural successor to beginner textbooks like Genki, Quartet develops all fou
 - [KaChiKa JA](https://kachika.app/) - AI photo-to-vocabulary app with example sentences and FSRS review; images stored on-device :iphone: :moneybag: :robot:.
 - [WordMeadow](https://wordmeadow.app/learn/japanese/from/english/themes) - Visual Japanese vocabulary theme cards grouped by everyday topics :computer: :baby:.
 - [Onomanabi](https://onomanabi.take-lab.com/) - Onomatopoeia trainer with an animation for every word, native notes, and similar-word maps :iphone: :computer: :moneybag: :robot:.
-- [WaseiGo](https://waseigo.take-lab.com/) - 1,000+ wasei-eigo words that look like English but mean something else, with illustrated dialogues :iphone: :moneybag: :robot:.
+- [WaseiGo](https://waseigo.take-lab.com/) - 1,000+ wasei-eigo words that look like English but mean something else, with illustrated dialogues :iphone: :computer: :moneybag: :robot:.
 
 ## Grammar
 

--- a/readme.md
+++ b/readme.md
@@ -180,8 +180,8 @@ The natural successor to beginner textbooks like Genki, Quartet develops all fou
 - [Pokelingo](https://pokelingo.io/en/riddle/?lang=ja) - Daily puzzle: read a Pokédex entry in Japanese and guess the Pokémon; all 1,025 names in katakana :iphone: :baby:.
 - [KaChiKa JA](https://kachika.app/) - AI photo-to-vocabulary app with example sentences and FSRS review; images stored on-device :iphone: :moneybag: :robot:.
 - [WordMeadow](https://wordmeadow.app/learn/japanese/from/english/themes) - Visual Japanese vocabulary theme cards grouped by everyday topics :computer: :baby:.
-- [Onomanabi](https://onomanabi.take-lab.com/) - Onomatopoeia trainer with an animation for every word, native notes, and similar-word maps :iphone: :computer: :moneybag: :robot:.
-- [WaseiGo](https://waseigo.take-lab.com/) - 1,000+ wasei-eigo words that look like English but mean something else, with illustrated dialogues :iphone: :computer: :moneybag: :robot:.
+- [Onomanabi](https://onomanabi.take-lab.com/) - Onomatopoeia trainer with an animation for every word, native notes, and similar-word maps :iphone: :moneybag: :robot:.
+- [WaseiGo](https://waseigo.take-lab.com/) - 1,000+ wasei-eigo words that look like English but mean something else, with illustrated dialogues :iphone: :moneybag: :robot:.
 
 ## Grammar
 


### PR DESCRIPTION
## Description
Adds two Japanese vocabulary apps to the **Vocabulary** section:

- **Onomanabi** — an onomatopoeia trainer. Every entry has an animation that expresses how the word feels, a native-speaker note, and a usage map comparing easily confused neighbors (ザーザー vs しとしと, ふわふわ vs もちもち). 1,500+ words across six levels; iOS / Android / Web.
- **WaseiGo** — covers 1,000+ wasei-eigo ("English-looking" Japanese words like マンション and クレーム whose meanings diverged from English), each taught through an illustrated two-voice dialogue with native audio; iOS / Android / Web.

I am the developer of both (native Japanese speaker, solo dev) — affiliation ticked below.

## Type of change
- [x] New addition to the list
- [ ] Update to an existing item
- [ ] Removal of an item
- [ ] Documentation improvement

## Checklist
- [x] I have read the [contribution guidelines](contributing.md)
- [x] The item I am adding is awesome and fits the theme of this list
- [x] The link is working and points to the intended content
- [x] The description is concise and informative, and does not use the word "free" (items without `:moneybag:` are already considered free)
- [x] Pricing is marked correctly: I added the `:moneybag:` emoji if the item has freemium tiers, in-app purchases, or paid plans
- [x] Generative AI is marked correctly: I added the `:robot:` emoji if the item uses generative AI in the product, or if generative AI did most (>50%) of building it
- [x] If the item starts charging money after this PR is merged (paid plans, in-app purchases, or freemium tiers), I will revise its description here to add the `:moneybag:` emoji — otherwise the entry may be removed without warning
- [x] Item description is under 100 characters (excluding emoji)
- [x] I have added the item to the appropriate category
- [x] If this PR resolves an issue, I linked it with `Closes #<number>` in the description above (no linked issue — this PR does not resolve one)
- [x] I understand this PR may be automatically closed after 90 days if there is no follow-up after a requested change, and that closing it will also close any issue it is linked to

## Your Role
- [x] I'm affiliated with this item
- [ ] I'm nominating this item

## Survey: AI Assistance (Optional)
- [ ] Little to none (<10%) — I wrote it myself
- [ ] Side by side (~10-50%) — AI assisted, I directed
- [x] Mostly AI (>50%) — AI did most of the work

## Additional Notes
Both apps are one-time purchase (no subscription) with a usable free tier, hence `:moneybag:`. The `:robot:` marks that AI coding tools did most of the implementation; the word data and dialogues were reviewed by me as a native speaker.
