### PR TITLE
Serve the site from awesome-japanese.japantv.app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tv/schedule.json
 /index.html
 /assets/
 /sitemap.xml
+/robots.txt

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,0 @@
-User-agent: *
-Allow: /
-Sitemap: https://yudataguy.github.io/Awesome-Japanese/sitemap.xml

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -10,7 +10,9 @@ import { marked } from "marked";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, "..");
 
-const SITE_URL = "https://yudataguy.github.io/awesome-japanese/";
+// The one place the public origin is written down: template.html, sitemap.xml and
+// robots.txt all derive from it, so a domain move is a one-line change here.
+const SITE_URL = "https://awesome-japanese.japantv.app/";
 
 // GitHub emoji shortcodes used in the readme -> real emoji (so the page matches GitHub).
 const EMOJI = {
@@ -76,11 +78,18 @@ function sitemap() {
   );
 }
 
+function robots() {
+  return `User-agent: *\nAllow: /\n\nSitemap: ${SITE_URL}sitemap.xml\n`;
+}
+
 const readme = await readFile(join(ROOT, "readme.md"), "utf8");
 const template = await readFile(join(__dirname, "template.html"), "utf8");
 
 const { html, tocHtml } = buildContent(readme);
-const page = template.replace("{{TOC}}", tocHtml).replace("{{CONTENT}}", html);
+const page = template
+  .replaceAll("{{SITE_URL}}", SITE_URL)
+  .replace("{{TOC}}", tocHtml)
+  .replace("{{CONTENT}}", html);
 
 await mkdir(join(ROOT, "assets"), { recursive: true });
 await copyFile(join(__dirname, "home.css"), join(ROOT, "assets", "home.css"));
@@ -88,5 +97,6 @@ await copyFile(join(__dirname, "share.js"), join(ROOT, "assets", "share.js"));
 await copyFile(join(__dirname, "social-preview.png"), join(ROOT, "assets", "social-preview.png"));
 await writeFile(join(ROOT, "index.html"), page);
 await writeFile(join(ROOT, "sitemap.xml"), sitemap());
+await writeFile(join(ROOT, "robots.txt"), robots());
 
-console.log("Built index.html, assets/home.css, sitemap.xml");
+console.log("Built index.html, assets/home.css, sitemap.xml, robots.txt");

--- a/site/template.html
+++ b/site/template.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Awesome Japanese — Curated Learning Resources</title>
   <meta name="description" content="A hand-curated list of the best resources for learning Japanese: textbooks, courses, kanji, grammar, listening, reading, dictionaries, apps, and a Japanese TV guide for immersion.">
-  <link rel="canonical" href="https://yudataguy.github.io/awesome-japanese/">
+  <link rel="canonical" href="{{SITE_URL}}">
   <meta name="theme-color" content="#be3b2e">
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23be3b2e'/%3E%3Ctext x='16' y='23' font-size='19' text-anchor='middle' fill='%23f5f1e8' font-family='serif' font-weight='700'%3E%E5%92%8C%3C/text%3E%3C/svg%3E">
 
@@ -14,9 +14,9 @@
   <meta property="og:site_name" content="Awesome Japanese">
   <meta property="og:title" content="Awesome Japanese — Curated Learning Resources">
   <meta property="og:description" content="The best resources to learn Japanese — textbooks, courses, kanji, grammar, listening, dictionaries, apps, and a Japanese TV guide for immersion.">
-  <meta property="og:url" content="https://yudataguy.github.io/awesome-japanese/">
-  <meta property="og:image" content="https://yudataguy.github.io/awesome-japanese/assets/social-preview.png">
-  <meta property="og:image:secure_url" content="https://yudataguy.github.io/awesome-japanese/assets/social-preview.png">
+  <meta property="og:url" content="{{SITE_URL}}">
+  <meta property="og:image" content="{{SITE_URL}}assets/social-preview.png">
+  <meta property="og:image:secure_url" content="{{SITE_URL}}assets/social-preview.png">
   <meta property="og:image:type" content="image/png">
   <meta property="og:image:width" content="1280">
   <meta property="og:image:height" content="640">
@@ -27,7 +27,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Awesome Japanese — Learn Japanese">
   <meta name="twitter:description" content="A hand-curated list of the best Japanese learning resources, plus a TV guide for immersion.">
-  <meta name="twitter:image" content="https://yudataguy.github.io/awesome-japanese/assets/social-preview.png">
+  <meta name="twitter:image" content="{{SITE_URL}}assets/social-preview.png">
   <meta name="twitter:image:alt" content="Awesome Japanese — a sumi-e ink painting of Mount Fuji with a red sun">
 
   <script type="application/ld+json">
@@ -35,7 +35,7 @@
     "@context": "https://schema.org",
     "@type": "CollectionPage",
     "name": "Awesome Japanese",
-    "url": "https://yudataguy.github.io/awesome-japanese/",
+    "url": "{{SITE_URL}}",
     "description": "A curated list of Japanese language learning resources.",
     "inLanguage": "en",
     "about": { "@type": "Language", "name": "Japanese" }
@@ -69,7 +69,7 @@
       </a>
       <div class="hero-share share-wrap">
         <button class="share-btn" type="button" aria-label="Share Awesome Japanese"
-                data-url="https://yudataguy.github.io/awesome-japanese/"
+                data-url="{{SITE_URL}}"
                 data-title="Awesome Japanese — Learn Japanese"
                 data-text="A hand-curated list of the best resources to learn Japanese 🇯🇵">↗ Share this guide</button>
         <div class="share-menu" hidden></div>
@@ -84,7 +84,7 @@
       <nav>{{TOC}}</nav>
       <div class="toc-share share-wrap">
         <button class="share-btn" type="button" aria-label="Share Awesome Japanese"
-                data-url="https://yudataguy.github.io/awesome-japanese/"
+                data-url="{{SITE_URL}}"
                 data-title="Awesome Japanese — Learn Japanese"
                 data-text="A hand-curated list of the best resources to learn Japanese 🇯🇵">↗ Share this guide</button>
         <div class="share-menu" hidden></div>


### PR DESCRIPTION
# Awesome-Japanese Pull Request

## Description
Serves the site from `awesome-japanese.japantv.app` and reduces the origin to one constant.

DNS is already live: `awesome-japanese.japantv.app` CNAMEs to `yudataguy.github.io.` (Namecheap).

- `site/template.html`: eight hardcoded `yudataguy.github.io/awesome-japanese/` literals (canonical, `og:url`, `og:image`, `og:image:secure_url`, `twitter:image`, JSON-LD `url`, two share `data-url`s) become `{{SITE_URL}}`, matching the existing `{{TOC}}`/`{{CONTENT}}` convention.
- `site/build.mjs`: `SITE_URL` points at the new origin and is substituted with `replaceAll` — `.replace()` would only fix the first of the eight.
- `robots.txt` is now generated from `SITE_URL` instead of being a static file. The static copy had drifted to the capitalized `Awesome-Japanese` path, which 404s.

Merge this **before** the workflow PR. Pushes to `homepage` do not trigger the deploy workflow, so this order never leaves a deploy without a generated `robots.txt`.

## Type of change
- [ ] New addition to the list
- [ ] Update to an existing item
- [ ] Removal of an item
- [x] Documentation improvement

## Checklist
- [x] I have read the [contribution guidelines](contributing.md)
- [x] The item I am adding is awesome and fits the theme of this list
- [x] The link is working and points to the intended content
- [x] The description is concise and informative, and does not use the word "free" (items without `:moneybag:` are already considered free)
- [x] Pricing is marked correctly: I added the `:moneybag:` emoji if the item has freemium tiers, in-app purchases, or paid plans
- [x] Generative AI is marked correctly: I added the `:robot:` emoji if the item uses generative AI in the product, or if generative AI did most (>50%) of building it
- [x] If the item starts charging money after this PR is merged (paid plans, in-app purchases, or freemium tiers), I will revise its description here to add the `:moneybag:` emoji — otherwise the entry may be removed without warning
- [x] Item description is under 100 characters (excluding emoji)
- [x] I have added the item to the appropriate category
- [x] If this PR resolves an issue, I linked it with `Closes #<number>` in the description above
- [x] I understand this PR may be automatically closed after 90 days if there is no follow-up after a requested change, and that closing it will also close any issue it is linked to

## Your Role
- [ ] I'm affiliated with this item
- [x] I'm nominating this item

## Additional Notes
Infrastructure change; the list content is untouched. Verified locally: `node site/build.mjs` emits eight `awesome-japanese.japantv.app` references in `index.html`, a matching `sitemap.xml`, and the corrected `robots.txt`. The remaining `github.io` strings in the output are third-party resource links from the readme.
