### PR TITLE
Publish a CNAME for the awesome-japanese.japantv.app custom domain

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -2,7 +2,8 @@ name: Deploy site
 
 # Builds the themed homepage from main's readme.md using the theme + build
 # tooling that lives on the `homepage` branch, then deploys it to GitHub Pages
-# via the official artifact flow. main stays clean (learning material only);
+# via the official artifact flow, served at https://awesome-japanese.japantv.app.
+# main stays clean (learning material only);
 # all website code lives on `homepage`. The TV app now lives in its own repo
 # (japantvapp -> https://japantv.app).
 # Requires: repo Settings -> Pages -> Source = "GitHub Actions".
@@ -37,7 +38,7 @@ jobs:
           path: .homepage
       - name: Stage website tooling from the homepage branch
         run: |
-          cp -r .homepage/site .homepage/package.json .homepage/package-lock.json .homepage/robots.txt .homepage/.nojekyll .
+          cp -r .homepage/site .homepage/package.json .homepage/package-lock.json .homepage/.nojekyll .
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
@@ -47,6 +48,9 @@ jobs:
         run: |
           mkdir -p _site
           cp -r index.html assets sitemap.xml robots.txt .nojekyll _site/
+          # Artifact deploys publish only what is in _site, so the custom domain
+          # has to be re-stated on every run or Pages drops back to github.io.
+          echo "awesome-japanese.japantv.app" > _site/CNAME
           for f in readme.md mobile.md; do [ -f "$f" ] && cp "$f" _site/; done
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5


### PR DESCRIPTION
# Awesome-Japanese Pull Request

## Description
Publishes a `CNAME` in the Pages artifact so deploys keep `awesome-japanese.japantv.app`.

Artifact deploys publish only the contents of `_site`. Unlike a branch-based deploy there is no `CNAME` file that persists between runs, so the domain has to be written into the artifact on every run — otherwise a later deploy silently reverts the site to `yudataguy.github.io/awesome-japanese`.

Also drops `robots.txt` from the homepage-branch staging step: it is now generated by `site/build.mjs` (from `SITE_URL`), and the assemble step still picks it up from the build output.

Depends on #170 — merge that one first. Pushes to `homepage` do not trigger this workflow, so that order never leaves a deploy without a generated `robots.txt`.

Requires repo Settings → Pages → Custom domain to be set to `awesome-japanese.japantv.app`. DNS is already live (Namecheap CNAME → `yudataguy.github.io.`).

## Type of change
- [ ] New addition to the list
- [ ] Update to an existing item
- [ ] Removal of an item
- [x] Documentation improvement

## Checklist
- [x] I have read the [contribution guidelines](contributing.md)
- [x] The item I am adding is awesome and fits the theme of this list
- [x] The link is working and points to the intended content
- [x] The description is concise and informative, and does not use the word "free" (items without `:moneybag:` are already considered free)
- [x] Pricing is marked correctly: I added the `:moneybag:` emoji if the item has freemium tiers, in-app purchases, or paid plans
- [x] Generative AI is marked correctly: I added the `:robot:` emoji if the item uses generative AI in the product, or if generative AI did most (>50%) of building it
- [x] If the item starts charging money after this PR is merged (paid plans, in-app purchases, or freemium tiers), I will revise its description here to add the `:moneybag:` emoji — otherwise the entry may be removed without warning
- [x] Item description is under 100 characters (excluding emoji)
- [x] I have added the item to the appropriate category
- [x] If this PR resolves an issue, I linked it with `Closes #<number>` in the description above
- [x] I understand this PR may be automatically closed after 90 days if there is no follow-up after a requested change, and that closing it will also close any issue it is linked to

## Your Role
- [ ] I'm affiliated with this item
- [x] I'm nominating this item

## Additional Notes
Infrastructure change; the list content is untouched. Merging this to `main` triggers a deploy.
