### PR TITLE
Add Japan Local Radio to Listening

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -228,6 +228,7 @@ The natural successor to beginner textbooks like Genki, Quartet develops all fou
 - [mykikitori](https://www.mykikitori.com/) - Practice your Japanese listening skills.
 - [Tsunahiro](https://tsunagarujp.mext.go.jp/) - Website for Foreign Nationals as Residents to Learn Japanese Language.
 - [ListenRadio (リスラジ)](https://listenradio.jp/) - Live streams from community FM stations across Japan :jp: :japan: :iphone:.
+- [Japan Local Radio](https://radio.japantv.app) - Browse 338 community FM and NHK stations by prefecture or map :japan: :robot:.
 - Podcast
   - [Podcast Ranking](https://podcastranking.jp/) - Japanese Podcast ranking website, discover Japanese language podcasts.
   - [Learn Japanese Pod](https://learnjapanesepod.com/) - Japanese language learning podcast.


### PR DESCRIPTION
# Awesome-Japanese Pull Request

## Description
Adds [Japan Local Radio](https://radio.japantv.app) to **Listening** — a directory of 338 community FM and NHK stations across all 47 prefectures, playable in the browser.

Placed directly after the ListenRadio entry, which covers the same community-FM ground.

Indicators:
- `:japan:` — streams are restricted to Japanese IPs, matching the ListenRadio entry above it.
- `:robot:` — generative AI did most (>50%) of the building.
- No `:jp:` — the site ships both `/ja/` and `/en/`, declared via `hreflang` alternates.

## Type of change
- [x] New addition to the list
- [ ] Update to an existing item
- [ ] Removal of an item
- [ ] Documentation improvement

## Checklist
- [x] I have read the [contribution guidelines](contributing.md)
- [x] The item I am adding is awesome and fits the theme of this list
- [x] The link is working and points to the intended content
- [x] The description is concise and informative, and does not use the word "free" (items without `:moneybag:` are already considered free)
- [x] Pricing is marked correctly: I added the `:moneybag:` emoji if the item has freemium tiers, in-app purchases, or paid plans
- [x] Generative AI is marked correctly: I added the `:robot:` emoji if the item uses generative AI in the product, or if generative AI did most (>50%) of building it
- [x] If the item starts charging money after this PR is merged (paid plans, in-app purchases, or freemium tiers), I will revise its description here to add the `:moneybag:` emoji — otherwise the entry may be removed without warning
- [x] Item description is under 100 characters (excluding emoji)
- [x] I have added the item to the appropriate category
- [x] If this PR resolves an issue, I linked it with `Closes #<number>` in the description above
- [x] I understand this PR may be automatically closed after 90 days if there is no follow-up after a requested change, and that closing it will also close any issue it is linked to

## Your Role
- [x] I'm affiliated with this item
- [ ] I'm nominating this item

## Survey: AI Assistance (Optional)
- [ ] Little to none (<10%) — I wrote it myself
- [ ] Side by side (~10–50%) — AI assisted, I directed
- [x] Mostly AI (>50%) — AI did most of the work

## Additional Notes
Description is 61 characters excluding emoji. `markdownlint-cli2` passes with 0 issues.

Merging this also clears the failed deploy from #171 — that run died on the merge-order race, and the site is currently serving the stale build from #167. A push to `main` re-triggers the workflow with both branches correctly paired.
