### PR TITLE
Require self-nominated items to be 6+ months old and, if paid, have 100+ users

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@
 <!-- If this PR resolves an open issue, write "Closes #<number>" here so the issue is linked and closes with this PR. -->
 <!-- Pricing: do NOT use the word "free" — items without `:moneybag:` are already considered free. If the item has freemium tiers, in-app purchases, or paid plans, add the `:moneybag:` emoji. -->
 <!-- Generative AI: add the `:robot:` emoji if the item uses generative AI in the product, or if AI did most (>50%) of building it — see the AI Assistance survey below. -->
+<!-- Self-nominations: this list is not a marketing channel. If you built this item, it must be at least 6 months old and, if paid, have at least 100 users — fill in the Self-Nomination Eligibility section below. -->
 <!-- Editorial independence: listings are not for sale and never depend on linking back. If this item is merged you're welcome to display the "Featured on Awesome Japanese" badge, but it is entirely optional — see contributing.md. -->
 
 ## Type of change
@@ -33,6 +34,16 @@
 <!-- Please choose one option that applies to you -->
 - [ ] I'm affiliated with this item
 - [ ] I'm nominating this item
+
+## Self-Nomination Eligibility
+<!-- Only required if you ticked "I'm affiliated with this item" above — otherwise leave this section as is. See "Eligibility for Self-Nominated Items" in contributing.md. -->
+- [ ] The item has been publicly available for at least 6 months
+- [ ] The item has no paid plans, in-app purchases, or freemium tiers — OR it does and has at least 100 users
+- [ ] I have provided proof below (public records), or stated below that I will provide it privately to a maintainer
+
+### Proof of eligibility
+<!-- Public records: paste links here (launch post, changelog, app store listing with release date, Wayback Machine snapshot, public download/review counts, etc.). -->
+<!-- Private records (analytics, store console, billing dashboard): do NOT post them here — write "Will provide privately" and a maintainer will reach out. -->
 
 ## Survey: AI Assistance (Optional)
 <!-- Optional survey, only asked if you're affiliated with this item (you ticked "I'm affiliated with this item" above). Roughly how much AI was involved in finding/writing this contribution? Pick one — any honest answer is welcome. -->

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -49,8 +49,9 @@ jobs:
             // - "Type of change" / "Your Role" are pick-one  -> min: 1
             // - "Checklist" items are all mandatory affirmations -> requireAll
             // To relax a section later, change `min` or drop `requireAll`.
-            // "Survey: AI Assistance (Optional)" is handled separately below --
-            // it is only enforced when the submitter is affiliated with the item.
+            // "Survey: AI Assistance (Optional)" and "Self-Nomination Eligibility"
+            // are handled separately below -- they are only enforced when the
+            // submitter is affiliated with the item.
             const SECTION_RULES = [
               { header: "Type of change", min: 1 },
               { header: "Checklist", requireAll: true },
@@ -105,6 +106,21 @@ jobs:
               .split("\n")
               .some((l) => /^\s*- \[(x|X)\].*affiliated with this item/.test(l));
             if (isAffiliated) {
+              // Self-nominated items must be >= 6 months old and, if paid,
+              // have >= 100 users, with proof (see contributing.md). All
+              // eligibility boxes are required for affiliated submitters.
+              const ELIGIBILITY = "Self-Nomination Eligibility";
+              const elig = sections[ELIGIBILITY];
+              if (!elig || elig.total === 0) {
+                problems.push(
+                  `The **${ELIGIBILITY}** section is missing. Please don't delete parts of the template — fill it in instead.`
+                );
+              } else if (elig.ticked < elig.total) {
+                problems.push(
+                  `**${ELIGIBILITY}**: since you're affiliated with this item, please confirm all ${elig.total} eligibility requirements (currently ${elig.ticked}/${elig.total}) and attach proof — see [contributing.md](https://github.com/${owner}/${repo}/blob/main/contributing.md#eligibility-for-self-nominated-items).`
+                );
+              }
+
               const SURVEY = "Survey: AI Assistance (Optional)";
               const survey = sections[SURVEY];
               if (!survey || survey.total === 0) {

--- a/contributing.md
+++ b/contributing.md
@@ -16,6 +16,20 @@ Thank you for your interest in contributing to the Awesome Japanese List! We're 
 
 Self-nominations are welcome — if you built an app, site, or resource that fits the list, you're encouraged to submit it. We only ask that you're up front about it: in your pull request, tick **"I'm affiliated with this item"** under *Your Role* so we can note the affiliation for transparency. Submissions are judged on the same quality bar as any other, regardless of who submits them.
 
+#### Eligibility for Self-Nominated Items
+
+Awesome Japanese is a curated list of genuinely useful Japanese-language content and tools. It is **not** a place for marketing or self-promotion, and a listing is not a launch announcement. To keep self-nominations to resources with a proven track record, an item you nominate yourself must meet **both** of the following:
+
+1. **At least 6 months old.** The item must have been publicly available for at least six months before the pull request is opened. Betas and soft launches count from the date the public could actually use it.
+2. **At least 100 users, if it's paid.** If the item has paid plans, in-app purchases, or freemium tiers (i.e. it carries the `:moneybag:` emoji), it must have at least 100 users (registered accounts, active subscribers, or paying customers — any honest measure is fine).
+
+**Proof is required.** Tick the boxes under *Self-Nomination Eligibility* in the pull request template and attach evidence. Either kind is accepted:
+
+- **Public records** — for example a dated launch post, changelog, blog announcement, App Store or Google Play listing showing the release date, Wayback Machine snapshot, public download or review counts, or a press mention.
+- **Private records** — for example a screenshot of your analytics, store console, or billing dashboard. Don't post private records on the public pull request; instead say in the PR that you'll provide proof privately, and a maintainer will reach out to arrange it. Private records are used only to verify eligibility and are never published.
+
+Self-nominated pull requests that don't meet these requirements, or that lack proof, will be closed. You're welcome to resubmit once the item qualifies. These requirements apply only to self-nominations — a resource nominated by an unaffiliated third party is not subject to them.
+
 ### Improving Existing Resources
 
 - If you notice a resource that could be improved or updated, please open an issue detailing your proposed changes.
@@ -55,6 +69,7 @@ Add each item as a single list line in the form:
 - Provide a clear and concise description for each contribution.
 - Check your spelling and grammar.
 - Please disclose any affiliation if you own or are connected to the resource, so we can note it for transparency (see *Nominating Your Own App or Resource* above).
+- Self-nominated items must be at least 6 months old and, if paid, have at least 100 users, with proof (see *Eligibility for Self-Nominated Items* above).
 - Read **Editorial Independence** below before submitting an item you're connected to.
 
 ## Editorial Independence


### PR DESCRIPTION
## Summary
- **contributing.md**: new *Eligibility for Self-Nominated Items* subsection. Self-nominated items must be publicly available for at least 6 months and, if paid (`:moneybag:`), have at least 100 users. Proof is required, either public records (launch post, store listing, Wayback snapshot, etc.) or private records shared with a maintainer. States plainly that the list is not a marketing or self-promotion channel.
- **PR template**: new *Self-Nomination Eligibility* section with three boxes plus a *Proof of eligibility* block. Only required when the submitter is affiliated with the item.
- **pr-template-check.yml**: enforces the new section only when "I'm affiliated with this item" is ticked, using the same gate as the AI survey. Unaffiliated nominations are unaffected.

Announcement issue is pinned separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4V7am5jam6eUhz6ADW7BB